### PR TITLE
Codechange: Use custom tags for non-translatable strings, add website to GRF settings menu

### DIFF
--- a/src/custom_tags.txt
+++ b/src/custom_tags.txt
@@ -1,2 +1,3 @@
 TITLE               :Chuffing Stations
 VERSION             :v1.1
+WEBSITE             :https://github.com/andybiotic/chuffing_stations

--- a/src/custom_tags.txt
+++ b/src/custom_tags.txt
@@ -1,0 +1,2 @@
+TITLE               :Chuffing Stations
+VERSION             :v1.1

--- a/src/header.nml
+++ b/src/header.nml
@@ -2,6 +2,7 @@ grf {
     grfid: "NDY\05";
     name: string(STR_GRF_NAME);
     desc: string(STR_GRF_DESCRIPTION);
+    url: string(STR_GRF_WEBSITE);
     version: 11;
     min_compatible_version: 10;
 }

--- a/src/lang/english.lng
+++ b/src/lang/english.lng
@@ -2,6 +2,8 @@
 STR_GRF_NAME                                                    :{TITLE} {VERSION}
 STR_GRF_DESCRIPTION                                             :{ORANGE}{TITLE}{}{BLACK}This station set is based on some common designs from around the UK.
 
+STR_GRF_WEBSITE                                                 :{WEBSITE}
+
 STR_VERSION_22723                                               :1.2.0 (r22723)
 
 STR_NAME_STATCLASS                                              :Platforms

--- a/src/lang/english.lng
+++ b/src/lang/english.lng
@@ -1,6 +1,6 @@
 ##grflangid 0x01
-STR_GRF_NAME                                                    :Chuffing Stations v1.1
-STR_GRF_DESCRIPTION                                             :{ORANGE}Chuffing Stations{}{BLACK}This station set is based on some common designs from around the UK.
+STR_GRF_NAME                                                    :{TITLE} {VERSION}
+STR_GRF_DESCRIPTION                                             :{ORANGE}{TITLE}{}{BLACK}This station set is based on some common designs from around the UK.
 
 STR_VERSION_22723                                               :1.2.0 (r22723)
 


### PR DESCRIPTION
NewGRF titles and version numbers are not translated and need to be updated frequently, independently of translations. This PR moves them to a new `custom_tags` file where they can be changed once and automatically changed for all translations.

While I was at it, I added a link to this repo to the NewGRF Settings menu.

![website](https://github.com/user-attachments/assets/2b92902e-d522-4b93-8292-f427a52f72a6)
