### PR TITLE
Cleanup: Remove trailing whitespace in all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Inspired by the diverse history of rail transport across the United Kingdom, **Chuffing Stations** is intended to provide players with a wide range of modular station tiles. It features platform and building designs from the pioneering days of the Industrial Revolution through to the cutting-edge technology of modern high-speed trains.
 
-Chuffing Stations is designed to be highly flexible while also matching the charm and character of the classic OpenTTD graphics. 
+Chuffing Stations is designed to be highly flexible while also matching the charm and character of the classic OpenTTD graphics.
 
 I hope you enjoy this set.
 
@@ -29,14 +29,14 @@ To play with Chuffing Stations, you can download the latest version using the Op
 Many thanks to everyone who has contributed to maintaining and developing OpenTTD over the years. Thank you to the various artists, coders and contributors of the many newGRFs that keep me playing. Special thanks to **andythenorth** and **Chris Sawyer**. I'd also like to thank 2TallTyler for their help with the build process and bug reporting.
 
 ### Credits
-Chuffing Stations contains some elements from [FIRS](https://github.com/andythenorth/firs) and [CHIPS](https://github.com/andythenorth/chips). 
+Chuffing Stations contains some elements from [FIRS](https://github.com/andythenorth/firs) and [CHIPS](https://github.com/andythenorth/chips).
 
 ## The Stations
 **Wooden**
 These basic platforms are typical of early railways and smaller branch lines. A few items of platform furniture are included, as well as some simple structures.
 
 **Stone**
-More sophisticated stations are often found on busier lines. Many of these stone buildings are inspired by the early buildings in the Great Western region. 
+More sophisticated stations are often found on busier lines. Many of these stone buildings are inspired by the early buildings in the Great Western region.
 
 **Red Brick**
 The elegant brick designs from around the Midland region inspired this station type.
@@ -72,7 +72,7 @@ Each of the station types (wooden, stone etc.) are written in their own NML file
 `chuffing_stations.nml` was created by manually copying and pasting the contents of the individual files into this one. You'll need to remove the newGRF header from each of the source files. On slightly older versions of OpenTTD (13 and lower) you may find that the smaller individual newGRFs work as expected, but the main GRF throws an error when loaded in OpenTTD. This appears to be resolved from version 14 onwards.
 
 ### Artwork and Workflow
-The png files are provided as-is, and licensed as above. Feel free to modify these. The graphics were created using the iPad app 'Pixaki'. These were exported in to GIMP where they were converted to the OTTD 8bpp palette. More information on my art workflow can be found in [example_stations](https://github.com/andybiotic/example_stations). 
+The png files are provided as-is, and licensed as above. Feel free to modify these. The graphics were created using the iPad app 'Pixaki'. These were exported in to GIMP where they were converted to the OTTD 8bpp palette. More information on my art workflow can be found in [example_stations](https://github.com/andybiotic/example_stations).
 
 
 

--- a/build.py
+++ b/build.py
@@ -58,7 +58,7 @@ processed_nml_file.close()
 
 print("#### nmlc ####")
 
-# Run 
+# Run
 nmlc = subprocess.run(["nmlc", "-c", "-t", f"src{os.path.sep}custom_tags.txt", "-l", f"src{os.path.sep}lang", "--grf", grf_name, merged_nml_path], stdout = subprocess.PIPE, stderr = subprocess.PIPE, text=True)
 print(nmlc.stdout)
 print(nmlc.stderr)

--- a/src/city.nml
+++ b/src/city.nml
@@ -1288,7 +1288,7 @@ spritelayout city_fenceandadvert_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;
@@ -1621,7 +1621,7 @@ spritelayout city_fenceandunderpass_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;

--- a/src/darkbrick.nml
+++ b/src/darkbrick.nml
@@ -1292,7 +1292,7 @@ spritelayout darkbrick_fenceandadvert_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;
@@ -1625,7 +1625,7 @@ spritelayout darkbrick_fenceandunderpass_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;
@@ -4835,7 +4835,7 @@ item(FEAT_STATIONS, darkbrick_signalbox_1a_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_DARKBRICK_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_SIGNALBOX);
-        
+
 
     }
     graphics {
@@ -4950,7 +4950,7 @@ item(FEAT_STATIONS, darkbrick_signalbox_2a_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_DARKBRICK_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_SIGNALBOX);
-        
+
 
     }
     graphics {

--- a/src/express.nml
+++ b/src/express.nml
@@ -1288,7 +1288,7 @@ spritelayout express_fenceandadvert_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;
@@ -1621,7 +1621,7 @@ spritelayout express_fenceandunderpass_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;

--- a/src/lang/english.lng
+++ b/src/lang/english.lng
@@ -35,7 +35,7 @@ STR_NAME_STATION_PLATFORM_UNDERPASS                             :Underpass
 STR_NAME_STATION_PLATFORM_OVERBRIDGE                            :Overbridge
 STR_NAME_STATION_PLATFORM_FOOTBRIDGE                            :Footbridge
 STR_NAME_STATION_PLATFORM_DISPLAYS                              :Platform With Digital Displays
-STR_NAME_STATION_PLATFORM_BUFFER                                :Buffer 
+STR_NAME_STATION_PLATFORM_BUFFER                                :Buffer
 STR_NAME_STATION_PLATFORM_STAIRS                                :Shelter with Stairs
 STR_NAME_STATION_PLATFORM_COVERED                               :Covered platforms
 STR_NAME_STATION_PLATFORM_ARCHED                                :Arched platforms
@@ -51,7 +51,7 @@ STR_NAME_STATION_SQUARE_FLOWERS                                 :Square with Flo
 STR_NAME_STATION_SQUARE_BUSH                                    :Square with Bushes
 STR_NAME_STATION_SQUARE_WATER                                   :Square with Water Feature
 
-STR_NAME_STATION_BUILDING                                       :Chuffing Buildings 
+STR_NAME_STATION_BUILDING                                       :Chuffing Buildings
 
 STR_NAME_STATION_MERSEY                                         :Mersey Ticket Office
 STR_NAME_STATION_NEWTON                                         :Newton Ticket Office

--- a/src/modern.nml
+++ b/src/modern.nml
@@ -1288,7 +1288,7 @@ spritelayout modern_fenceandadvert_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;
@@ -1621,7 +1621,7 @@ spritelayout modern_fenceandunderpass_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;
@@ -3554,7 +3554,7 @@ item(FEAT_STATIONS, modern_left_overbridge) {
         class:                  "_MDN";
         classname:              string(STR_NAME_STATCLASS_MODERN_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_FOOTBRIDGE);
-        
+
 
     }
     graphics {
@@ -3676,7 +3676,7 @@ item(FEAT_STATIONS, modern_right_overbridge) {
         class:                  "_MDN";
         classname:              string(STR_NAME_STATCLASS_MODERN_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_FOOTBRIDGE);
-        
+
 
     }
     graphics {
@@ -3933,7 +3933,7 @@ item(FEAT_STATIONS, modern_right_overbridgefences) {
         class:                  "_MDN";
         classname:              string(STR_NAME_STATCLASS_MODERN_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_FOOTBRIDGE);
-    
+
     }
     graphics {
         sprite_layouts: [modern_overbridgefences_right_sw_ne(0), modern_overbridgefences_right_se_nw(0)];
@@ -4275,7 +4275,7 @@ item(FEAT_STATIONS, modern_terminus) {
         classname:              string(STR_NAME_STATCLASS_MODERN_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_COVERED);
         disabled_platforms:     bitmask(1,3,4,5,6,7,8);
-        
+
 
     }
     graphics {
@@ -4965,7 +4965,7 @@ item(FEAT_STATIONS, modern_signalbox_1a_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_MODERN_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_SIGNALBOX);
-        
+
 
     }
     graphics {

--- a/src/redbrick.nml
+++ b/src/redbrick.nml
@@ -1293,7 +1293,7 @@ spritelayout redbrick_fenceandbench_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;
@@ -1626,7 +1626,7 @@ spritelayout redbrick_fenceandunderpass_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;
@@ -4311,7 +4311,7 @@ item(FEAT_STATIONS, redbrick_terminus) {
 spriteset (redbrick_arched_end_left, "src/stations_redbrick.png") {
     [  10, 850, 64, 64, -32, -34 ]
     [  80, 850, 64, 64, -32, -34 ]
-   
+
     [  220, 850, 64, 64, -32, -34 ]
     [  290, 850, 64, 64, -32, -34 ]
 }
@@ -4409,7 +4409,7 @@ item(FEAT_STATIONS, redbrick_arched_end) {
 spriteset (redbrick_arched_middle_left, "src/stations_redbrick.png") {
     [  10, 850, 64, 64, -32, -34 ]
     [  150, 850, 64, 64, -32, -34 ]
-   
+
     [  220, 850, 64, 64, -32, -34 ]
     [  360, 850, 64, 64, -32, -34 ]
 }
@@ -5209,7 +5209,7 @@ switch (FEAT_STATIONS, SELF, switch_redbrick_feature_building, platform_number_f
     1: return redbrick_feature_building_tile_1;
     2: return redbrick_feature_building_tile_2;
     3: return redbrick_feature_building_tile_3;
-    
+
 }
 
 item(FEAT_STATIONS, redbrick_feature_building) {
@@ -5428,7 +5428,7 @@ item(FEAT_STATIONS, redbrick_signalbox_1a_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_REDBRICK_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_SIGNALBOX);
-        
+
 
     }
     graphics {
@@ -5543,7 +5543,7 @@ item(FEAT_STATIONS, redbrick_signalbox_2a_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_REDBRICK_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_SIGNALBOX);
-        
+
 
     }
     graphics {

--- a/src/stone.nml
+++ b/src/stone.nml
@@ -1282,7 +1282,7 @@ spritelayout stone_fenceandbench_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;
@@ -3644,7 +3644,7 @@ spritelayout stone_covered_platforms_left_se_nw(a) {
         zextent:        40;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
 }
 
 item(FEAT_STATIONS, left_stone_covered_platforms) {
@@ -3763,7 +3763,7 @@ item(FEAT_STATIONS, right_stone_covered_platforms) {
 spriteset (stone_arched_end_left, "src/stations_stone.png") {
     [  10, 850, 64, 64, -32, -34 ]
     [  80, 850, 64, 64, -32, -34 ]
-   
+
     [  220, 850, 64, 64, -32, -34 ]
     [  290, 850, 64, 64, -32, -34 ]
 }
@@ -3861,7 +3861,7 @@ item(FEAT_STATIONS, stone_arched_end) {
 spriteset (stone_arched_middle_left, "src/stations_stone.png") {
     [  10, 850, 64, 64, -32, -34 ]
     [  150, 850, 64, 64, -32, -34 ]
-   
+
     [  220, 850, 64, 64, -32, -34 ]
     [  360, 850, 64, 64, -32, -34 ]
 }
@@ -4654,7 +4654,7 @@ switch (FEAT_STATIONS, SELF, switch_stone_feature_building, platform_number_from
     1: return stone_feature_building_tile_1;
     2: return stone_feature_building_tile_2;
     3: return stone_feature_building_tile_3;
-    
+
 }
 
 item(FEAT_STATIONS, stone_feature_building) {
@@ -4778,7 +4778,7 @@ switch (FEAT_STATIONS, SELF, switch_stone_feature_building_rear, platform_number
     1: return stone_feature_building_rear_tile_1;
     2: return stone_feature_building_rear_tile_2;
     3: return stone_feature_building_rear_tile_3;
-    
+
 }
 
 item(FEAT_STATIONS, stone_feature_building_rear) {
@@ -4889,7 +4889,7 @@ spritelayout stone_addon_1b_ne(a) {
 switch (FEAT_STATIONS, SELF, switch_stone_hotel_building, platform_position_from_start(PLATFORM_SAME_SECTION)) {
     0: return stone_addon_tile_0;
     1: return stone_addon_tile_1;
-    
+
 }
 
 item(FEAT_STATIONS, stone_station_addon_1a) {
@@ -5101,7 +5101,7 @@ item(FEAT_STATIONS, stone_left_overbridge_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_STONE_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_FOOTBRIDGE);
-        
+
 
     }
     graphics {
@@ -5171,7 +5171,7 @@ item(FEAT_STATIONS, stone_right_overbridge_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_STONE_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_FOOTBRIDGE);
-        
+
 
     }
     graphics {
@@ -5229,7 +5229,7 @@ item(FEAT_STATIONS, stone_signalbox_1a_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_STONE_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_SIGNALBOX);
-        
+
 
     }
     graphics {
@@ -5344,7 +5344,7 @@ item(FEAT_STATIONS, stone_signalbox_2a_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_STONE_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_SIGNALBOX);
-        
+
 
     }
     graphics {

--- a/src/stone_extra.nml
+++ b/src/stone_extra.nml
@@ -70,7 +70,7 @@ spritelayout stone_extra_covered_platforms_left_se_nw(a) {
         zextent:        40;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
 }
 
 item(FEAT_STATIONS, left_stone_extra_covered_platforms) {
@@ -191,7 +191,7 @@ item(FEAT_STATIONS, right_stone_extra_covered_platforms) {
 spriteset (stone_extra_arched_end_left, "src/stations_stone_extra.png") {
     [  10, 850, 64, 64, -32, -34 ]
     [  80, 850, 64, 64, -32, -34 ]
-   
+
     [  220, 850, 64, 64, -32, -34 ]
     [  290, 850, 64, 64, -32, -34 ]
 }
@@ -290,7 +290,7 @@ item(FEAT_STATIONS, stone_extra_arched_end) {
 spriteset (stone_extra_arched_middle_left, "src/stations_stone_extra.png") {
     [  10, 850, 64, 64, -32, -34 ]
     [  150, 850, 64, 64, -32, -34 ]
-   
+
     [  220, 850, 64, 64, -32, -34 ]
     [  360, 850, 64, 64, -32, -34 ]
 }

--- a/src/suburban.nml
+++ b/src/suburban.nml
@@ -1292,7 +1292,7 @@ spritelayout suburban_fenceandadvert_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;
@@ -1625,7 +1625,7 @@ spritelayout suburban_fenceandunderpass_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;
@@ -4872,7 +4872,7 @@ item(FEAT_STATIONS, suburban_signalbox_1a_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_SUBURBAN_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_SIGNALBOX);
-        
+
 
     }
     graphics {
@@ -4987,7 +4987,7 @@ item(FEAT_STATIONS, suburban_signalbox_2a_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_SUBURBAN_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_SIGNALBOX);
-        
+
 
     }
     graphics {
@@ -5102,7 +5102,7 @@ item(FEAT_STATIONS, suburban_signalbox_3a_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_SUBURBAN_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_SUBSTATION);
-        
+
 
     }
     graphics {

--- a/src/wooden.nml
+++ b/src/wooden.nml
@@ -963,7 +963,7 @@ spritelayout wooden_fenceandbench_platform_right_se_nw(a) {
         zextent:        12;
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
-    }    
+    }
     building {
         sprite:         DEFAULT(3);
         xoffset:        0;
@@ -1496,7 +1496,7 @@ spriteset (wooden_plain_north_end_left, "src/stations_wooden.png") {
     [  640, 10, 64, 64, -32, -34 ]
     [  10, 150, 64, 64, -32, -34 ]
     [  80, 150, 64, 64, -32, -34 ]
-    
+
 }
 
 spritelayout wooden_plain_north_end_left_sw_ne(a) {
@@ -1821,7 +1821,7 @@ spriteset (wooden_fence_north_end_left, "src/stations_wooden.png") {
     [  640, 80, 64, 64, -32, -34 ]
     [  10, 220, 64, 64, -32, -34 ]
     [  80, 220, 64, 64, -32, -34 ]
-    
+
 }
 
 spritelayout wooden_fence_north_end_left_sw_ne(a) {
@@ -1878,7 +1878,7 @@ spritelayout wooden_fence_north_end_left_se_nw(a) {
         recolour_mode:  RECOLOUR_REMAP;
         palette:        PALETTE_USE_DEFAULT;
     }
-    
+
 }
 
 item(FEAT_STATIONS, wooden_fence_north_end_left_station) {
@@ -2509,7 +2509,7 @@ item(FEAT_STATIONS, wood_sign_1a_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_WOODEN_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_WAYPOINT_SIGN);
-        
+
 
     }
     graphics {
@@ -2624,7 +2624,7 @@ item(FEAT_STATIONS, wood_sign_2a_waypoint) {
         class:                  "WAYP";
         classname:              string(STR_NAME_STATCLASS_WOODEN_PLATFORMS);
         name:                   string(STR_NAME_STATION_PLATFORM_WAYPOINT_SIGN);
-        
+
 
     }
     graphics {


### PR DESCRIPTION
Trailing whitespace is bad or something (it instantly fails the first automated check for PRs to OpenTTD itself).

Luckily, it's [easy to remove automatically](https://dotjesper.com/2024/how-to-remove-trailing-spaces-in-visual-studio-code/).