### PR TITLE
Add parameter to disable unlock dates for stations

### DIFF
--- a/src/header.nml
+++ b/src/header.nml
@@ -4,6 +4,13 @@ grf {
     desc: string(STR_GRF_DESCRIPTION);
     version: 11;
     min_compatible_version: 10;
+    param 1 {
+        param_disable_unlock_year {
+            type: bool;
+            name: string(STR_PARAM_DISABLE_UNLOCK_YEAR_NAME);
+            desc: string(STR_PARAM_DISABLE_UNLOCK_YEAR_DESCRIPTION);
+        }
+    }
 }
 
 if (version_openttd(1,2,0,22723) > openttd_version) {
@@ -15,37 +22,37 @@ cargotable {
 }
 
 switch (FEAT_STATIONS, SELF, switch_intro_year_redbrick, current_year) {
-  0..1884: 0;
+  0..1884: param[1] ? 1 : 0;
   default: 1;
 }
 
 switch (FEAT_STATIONS, SELF, switch_intro_year_stone_extra, current_year) {
-  0..1924: 0;
+  0..1924: param[1] ? 1 : 0;
   default: 1;
 }
 
 switch (FEAT_STATIONS, SELF, switch_intro_year_suburban, current_year) {
-  0..1924: 0;
+  0..1924: param[1] ? 1 : 0;
   default: 1;
 }
 
 switch (FEAT_STATIONS, SELF, switch_intro_year_darkbrick, current_year) {
-  0..1954: 0;
+  0..1954: param[1] ? 1 : 0;
   default: 1;
 }
 
 switch (FEAT_STATIONS, SELF, switch_intro_year_modern, current_year) {
-  0..1964: 0;
+  0..1964: param[1] ? 1 : 0;
   default: 1;
 }
 
 switch (FEAT_STATIONS, SELF, switch_intro_year_express, current_year) {
-  0..1979: 0;
+  0..1979: param[1] ? 1 : 0;
   default: 1;
 }
 
 switch (FEAT_STATIONS, SELF, switch_intro_year_city, current_year) {
-  0..2004: 0;
+  0..2004: param[1] ? 1 : 0;
   default: 1;
 }
 

--- a/src/lang/english.lng
+++ b/src/lang/english.lng
@@ -2,6 +2,9 @@
 STR_GRF_NAME                                                    :Chuffing Stations v1.1
 STR_GRF_DESCRIPTION                                             :{ORANGE}Chuffing Stations{}{BLACK}This station set is based on some common designs from around the UK.
 
+STR_PARAM_DISABLE_UNLOCK_YEAR_NAME                              :Disable unlock year for stations
+STR_PARAM_DISABLE_UNLOCK_YEAR_DESCRIPTION                       :Toggle whether all station types are available regardless of the in-game year.
+
 STR_VERSION_22723                                               :1.2.0 (r22723)
 
 STR_NAME_STATCLASS                                              :Platforms


### PR DESCRIPTION
Very simple PR which adds a parameter to make all stations available at all dates. I really don't like having arbitrary limitations in my eyecandy grfs, and it was an easy change to an otherwise great grf, so I figured I'd do it myself and see if it got picked up by upstream. Making it a parameter means that people who don't mind it can keep it and people who don't like it can get rid of it.